### PR TITLE
Added gems only filter

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,9 @@
 {
   "name": "exile-leveling",
+  "scripts": {
+    "run": "npm run dev -w web",
+    "seed-tree": "npm run seed tree -w seeding"
+  },
   "workspaces": [
     "seeding",
     "web"

--- a/web/src/components/TaskList/index.tsx
+++ b/web/src/components/TaskList/index.tsx
@@ -30,7 +30,7 @@ function TaskListItem({ children, isCompletedState }: TaskItemProps) {
   );
 }
 
-export type TaskListItem = (TaskItemProps & { key?: React.Key, type: "fragment_Step" | "gem_step" });
+export type TaskListItem = (TaskItemProps & { key?: React.Key, type: "fragment_step" | "gem_step" });
 
 export interface TaskListProps {
   items?: TaskListItem[];

--- a/web/src/components/TaskList/index.tsx
+++ b/web/src/components/TaskList/index.tsx
@@ -30,8 +30,10 @@ function TaskListItem({ children, isCompletedState }: TaskItemProps) {
   );
 }
 
+export type TaskListItem = (TaskItemProps & { key?: React.Key, type: "fragment_Step" | "gem_step" });
+
 export interface TaskListProps {
-  items?: (TaskItemProps & { key?: React.Key })[];
+  items?: TaskListItem[];
 }
 
 export function TaskList({ items }: TaskListProps) {

--- a/web/src/containers/Routes/index.tsx
+++ b/web/src/containers/Routes/index.tsx
@@ -11,14 +11,14 @@ import { withScrollRestoration } from "../../utility/withScrollRestoration";
 import { ReactNode } from "react";
 import { useRecoilValue } from "recoil";
 
-const showGemsOnly = false;
+const showGemsOnly = true;
 
-function FilterGemsOnly(taskItems: TaskListItem[]) {
+function filterGemsOnly(taskItems: TaskListItem[]) {
   const newTasksItems = [];
   for (let i = 0; i < taskItems.length; i++) {
     const nextStep: TaskListItem | undefined = taskItems[i+1];
 
-    if (taskItems[i].type === "fragment_Step" && nextStep?.type !== "gem_step") {
+    if (taskItems[i].type === "fragment_step" && nextStep?.type !== "gem_step") {
       continue;
     }
 
@@ -42,7 +42,7 @@ function RoutesContainer() {
 
       if (step.type == "fragment_step")
         taskItems.push({
-          type: "fragment_Step",
+          type: "fragment_step",
           key: stepIndex,
           isCompletedState: routeProgressSelectorFamily(
             [sectionIndex, stepIndex].toString()
@@ -66,7 +66,7 @@ function RoutesContainer() {
     }
 
     if (showGemsOnly) {
-      taskItems = FilterGemsOnly(taskItems);
+      taskItems = filterGemsOnly(taskItems);
     }
 
     items.push(

--- a/web/src/containers/Routes/index.tsx
+++ b/web/src/containers/Routes/index.tsx
@@ -2,7 +2,7 @@ import { ExileFragmentStep } from "../../components/ExileFragment";
 import { GemReward } from "../../components/ItemReward";
 import { SectionHolder } from "../../components/SectionHolder";
 import { Sidebar } from "../../components/Sidebar";
-import { TaskListProps } from "../../components/TaskList";
+import { TaskListItem, TaskListProps } from "../../components/TaskList";
 import { gemProgressSelectorFamily } from "../../state/gem-progress";
 import { routeSelector } from "../../state/route";
 import { routeProgressSelectorFamily } from "../../state/route-progress";
@@ -11,10 +11,28 @@ import { withScrollRestoration } from "../../utility/withScrollRestoration";
 import { ReactNode } from "react";
 import { useRecoilValue } from "recoil";
 
+const showGemsOnly = false;
+
+function FilterGemsOnly(taskItems: TaskListItem[]) {
+  const newTasksItems = [];
+  for (let i = 0; i < taskItems.length; i++) {
+    const nextStep: TaskListItem | undefined = taskItems[i+1];
+
+    if (taskItems[i].type === "fragment_Step" && nextStep?.type !== "gem_step") {
+      continue;
+    }
+
+    newTasksItems.push(taskItems[i]);
+  }
+
+  return newTasksItems;
+}
+
 function RoutesContainer() {
   const route = useRecoilValue(routeSelector);
 
   const items: ReactNode[] = [];
+
   for (let sectionIndex = 0; sectionIndex < route.length; sectionIndex++) {
     const section = route[sectionIndex];
 
@@ -24,6 +42,7 @@ function RoutesContainer() {
 
       if (step.type == "fragment_step")
         taskItems.push({
+          type: "fragment_Step",
           key: stepIndex,
           isCompletedState: routeProgressSelectorFamily(
             [sectionIndex, stepIndex].toString()
@@ -33,6 +52,7 @@ function RoutesContainer() {
 
       if (step.type == "gem_step")
         taskItems.push({
+          type: "gem_step",
           key: step.requiredGem.uid,
           isCompletedState: gemProgressSelectorFamily(step.requiredGem.uid),
           children: (
@@ -43,6 +63,10 @@ function RoutesContainer() {
             />
           ),
         });
+    }
+
+    if (showGemsOnly) {
+      taskItems = FilterGemsOnly(taskItems);
     }
 
     items.push(


### PR DESCRIPTION
The idea is:
I already know how to run acts, but with each build comes different gem setup
Everything other step than gems is just an unecary bloat for me
I propose adding a toggle somewhere to hide every step other than those which reward you with new gems (and gems themselfs)

Without filter: 
![image](https://user-images.githubusercontent.com/44632941/229915765-1bd45033-2f88-4b3b-8189-d2689cfdcaad.png)

With filter: 
![image](https://user-images.githubusercontent.com/44632941/229915961-8579c3f4-5f80-46d2-b50e-fb3f6049bb2b.png)
