### PR TITLE
style: add min-height to Viewport

### DIFF
--- a/web/src/components/PassiveTreeViewer/styles.module.css
+++ b/web/src/components/PassiveTreeViewer/styles.module.css
@@ -6,7 +6,8 @@
 }
 
 .viewport {
-  flex: 20rem;
+  display: flex;
+  flex-basis: 20rem;
   border-style: solid;
   border-width: var(--border-width);
   border-color: var(--accent-primary);

--- a/web/src/components/Viewport/styles.module.css
+++ b/web/src/components/Viewport/styles.module.css
@@ -3,6 +3,7 @@
   overflow: hidden;
   width: 100%;
   height: 100%;
+  min-height: 20rem;
 }
 
 .world {

--- a/web/src/components/Viewport/styles.module.css
+++ b/web/src/components/Viewport/styles.module.css
@@ -2,8 +2,6 @@
   position: relative;
   overflow: hidden;
   width: 100%;
-  height: 100%;
-  min-height: 20rem;
 }
 
 .world {


### PR DESCRIPTION
The height of the viewport div was zero on Safari, so set a min-value to make the skill tree visible.  Tested on MacOS chrome/safari/firefox.

fixes #51