### PR TITLE
Change Matrix3d transform into Translate & Scale transforms

### DIFF
--- a/web/src/components/Viewport/index.tsx
+++ b/web/src/components/Viewport/index.tsx
@@ -66,7 +66,6 @@ export function Viewport({
     const zoom = d3
       .zoom<HTMLDivElement, unknown>()
       .on("zoom", ({ transform }) => {
-        console.log(transform)
         worldSelection.style(
           "transform",
           `translate(${transform.x}px, ${transform.y}px) scale(${transform.k})`

--- a/web/src/components/Viewport/index.tsx
+++ b/web/src/components/Viewport/index.tsx
@@ -66,9 +66,10 @@ export function Viewport({
     const zoom = d3
       .zoom<HTMLDivElement, unknown>()
       .on("zoom", ({ transform }) => {
+        console.log(transform)
         worldSelection.style(
           "transform",
-          `matrix3d(${transform.k}, 0, 0, 0, 0, ${transform.k}, 0, 0, 0, 0, 1, 0, ${transform.x}, ${transform.y}, 0, 1)`
+          `translate(${transform.x}px, ${transform.y}px) scale(${transform.k})`
         );
       });
 


### PR DESCRIPTION
This should help reduce the browser load when calculating the repositioning of the tree viewer on devices with lower specs (e.g. mobile devices).