### PR TITLE
Minor order tweaks

### DIFF
--- a/common/data/routes/act-1.txt
+++ b/common/data/routes/act-1.txt
@@ -31,7 +31,8 @@ Hand in {quest|a1q2|a1q2b} #The Caged Brute
 #endif
 ➞ {enter|1_1_7_2} #The Upper Prison
 ➞ {arena|The Warden's Quarters}, kill {kill|Brutus, Lord Incarcerator}
-{logout}
+➞ {enter|1_1_8} #Prisoner's Gate
+{waypoint|1_1_town} #Lioneye's Watch
 Hand in {quest|a1q2|a1q2} #The Caged Brute
 {waypoint|1_1_8} #Prisoner's Gate
 Go down the ledge next to the road

--- a/common/data/routes/act-6.txt
+++ b/common/data/routes/act-6.txt
@@ -21,6 +21,9 @@ Get {crafting}
 ➞ {arena|The Warden's Chambers}
 Get {crafting}
 ➞ {enter|2_6_8} #Prisoner's Gate
+Go down the ledge next to the road
+➞ {arena|Valley of the Fire Drinker}, kill {kill|Abberath, the Cloven One}
+➞ {enter|2_6_8} #Prisoner's Gate
 Follow the road ➞ {enter|2_6_9} #The Western Forest
 Get {crafting}
 Follow the road ➞ {enter|2_6_10} #The Riverways
@@ -28,9 +31,10 @@ Follow the road, get {waypoint_get}
 Look for 2 pillars near {waypoint}, follow the trail ➞ {enter|2_6_11} #The Wetlands
 Head {dir|315} ➞ {arena|The Spawning Ground}, kill {kill|Ryslatha, the Puppet Mistress}
 {logout}
-Hand in {quest|a6q3} #The Father of War
 Hand in {quest|a6q2} #Essence of Umbra
+Hand in {quest|a6q3} #The Father of War
 Hand in {quest|a6q6} #The Puppet Mistress
+Hand in {quest|a6q7} #The Cloven One
 {waypoint|2_6_10} #The Riverways
 Follow the road until it ends
 Head {dir|135} ➞ {enter|2_6_12} #The Southern Forest

--- a/common/data/routes/act-7.txt
+++ b/common/data/routes/act-7.txt
@@ -38,11 +38,6 @@ Head {dir|225} ➞ {arena|The Forest Encampment}, kill {kill|Greust, Lord of the
 ➞ {enter|2_7_8} #The Northern Forest
 {waypoint|2_7_town} #The Bridge Encampment
 Hand in {quest|a7q1} #The Master of a Million Faces
-{waypoint|2_6_8} #Prisoner's Gate
-Go down the ledge next to the road
-➞ {arena|Valley of the Fire Drinker}, kill {kill|Abberath, the Cloven One}
-{portal|use}
-Hand in {quest|a6q7} #The Cloven One
 {waypoint|2_7_8} #The Northern Forest
 ➞ {enter|2_7_10} #The Causeway
 Get {crafting}


### PR DESCRIPTION
Some minor sensible adjustments to the default route

- Act 1
  - Added a step to get the Prisoner's Gate waypoint after killing Brutus.
- Act 6/7
  - Move the defeat and hand-in of Abberath from Act 7 to Act 6; this hopefully makes things more fluid, with less back-tracking