### PR TITLE
Not change portal area id after use of portal to go to town.

### DIFF
--- a/common/route-processing/fragment/index.ts
+++ b/common/route-processing/fragment/index.ts
@@ -300,7 +300,6 @@ function EvaluatePortal(
 
         const townArea = Data.Areas[currentArea.parent_town_area_id];
         transitionArea(state, townArea);
-        state.portalAreaId = state.currentAreaId;
       } else if (currentArea.id == portalArea.parent_town_area_id) {
         transitionArea(state, portalArea);
         state.portalAreaId = null;


### PR DESCRIPTION
When a portal is used to go to town, the portal area id is already set to the zone where the portal was summoned, and the current area id is set to town (as we have transitioned to this area), so do not change the portal zone id in the current state.