### PR TITLE
Add exclusion character for searchString copy functionality

### DIFF
--- a/web/src/components/CodeEditor/index.tsx
+++ b/web/src/components/CodeEditor/index.tsx
@@ -1,0 +1,38 @@
+import { formStyles } from "../../styles";
+import styles from "./styles.module.css";
+import classNames from "classnames";
+import { Grammar, highlight } from "prismjs";
+import Editor from "react-simple-code-editor";
+
+interface CodeEditorProps {
+  grammar: Grammar;
+  value: string;
+  onValueChange: (value: string) => void;
+}
+
+export function CodeEditor({
+  grammar,
+  value,
+  onValueChange,
+  className,
+  ...rest
+}: CodeEditorProps &
+  React.DetailedHTMLProps<
+    React.HTMLAttributes<HTMLDivElement>,
+    HTMLDivElement
+  >) {
+  return (
+    <div
+      className={classNames(className, formStyles.formInput, styles.editor)}
+      {...rest}
+    >
+      <Editor
+        highlight={(value) => highlight(value, grammar, "")}
+        tabSize={4}
+        textareaClassName={classNames(styles.editorTextArea)}
+        value={value}
+        onValueChange={onValueChange}
+      />
+    </div>
+  );
+}

--- a/web/src/components/CodeEditor/styles.module.css
+++ b/web/src/components/CodeEditor/styles.module.css
@@ -1,0 +1,9 @@
+.editor {
+  flex-grow: 1;
+  overflow-y: scroll;
+  font-family: "Consolas", monospace;
+}
+
+.editorTextArea {
+  outline: inherit;
+}

--- a/web/src/components/RouteEditor/Workspace/index.tsx
+++ b/web/src/components/RouteEditor/Workspace/index.tsx
@@ -1,11 +1,10 @@
 import { RouteData } from "../../../../../common/route-processing/types";
-import { formStyles } from "../../../styles";
+import { CodeEditor } from "../../CodeEditor";
 import { SelectList } from "../../SelectList";
 import styles from "./styles.module.css";
 import classNames from "classnames";
-import { Grammar, highlight } from "prismjs";
+import { Grammar } from "prismjs";
 import { useEffect, useRef, useState } from "react";
-import Editor from "react-simple-code-editor";
 
 const RouteGrammar: Grammar = {
   keyword: {
@@ -33,7 +32,7 @@ interface WorkspaceProps {
 }
 
 export function Workspace({ workingFiles, isDirty, onUpdate }: WorkspaceProps) {
-  const formInputRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLDivElement>(null);
   const [selectedIndex, setSelectedIndex] = useState<number>(0);
 
   useEffect(() => {
@@ -41,9 +40,9 @@ export function Workspace({ workingFiles, isDirty, onUpdate }: WorkspaceProps) {
   }, [workingFiles]);
 
   useEffect(() => {
-    if (formInputRef.current === null) return;
-    formInputRef.current.scrollTo(0, 0);
-  }, [selectedIndex, formInputRef]);
+    if (inputRef.current === null) return;
+    inputRef.current.scrollTo(0, 0);
+  }, [selectedIndex, inputRef]);
 
   return (
     <div className={classNames(styles.workspace)}>
@@ -60,22 +59,16 @@ export function Workspace({ workingFiles, isDirty, onUpdate }: WorkspaceProps) {
                 : workingFile.name;
             }}
           />
-          <div
-            ref={formInputRef}
-            className={classNames(formStyles.formInput, styles.editor)}
-          >
-            <Editor
-              value={workingFiles[selectedIndex].contents}
-              onValueChange={(value) => {
-                const updatedRouteFiles = [...workingFiles];
-                updatedRouteFiles[selectedIndex].contents = value;
-                onUpdate(updatedRouteFiles);
-              }}
-              highlight={(value) => highlight(value, RouteGrammar, "")}
-              tabSize={4}
-              textareaClassName={classNames(styles.editorTextArea)}
-            />
-          </div>
+          <CodeEditor
+            ref={inputRef}
+            grammar={RouteGrammar}
+            value={workingFiles[selectedIndex].contents}
+            onValueChange={(value) => {
+              const updatedRouteFiles = [...workingFiles];
+              updatedRouteFiles[selectedIndex].contents = value;
+              onUpdate(updatedRouteFiles);
+            }}
+          />
         </>
       )}
     </div>

--- a/web/src/components/SearchStrings/index.tsx
+++ b/web/src/components/SearchStrings/index.tsx
@@ -1,3 +1,4 @@
+import { SearchString } from "../../state/search-strings";
 import { borderListStyles, interactiveStyles } from "../../styles";
 import styles from "./styles.module.css";
 import classNames from "classnames";
@@ -5,48 +6,32 @@ import { FaRegClipboard } from "react-icons/fa";
 import { toast } from "react-toastify";
 
 interface SearchStringsProps {
-  values: string[];
+  values: SearchString[];
 }
 
 export function SearchStrings({ values }: SearchStringsProps) {
-
-  const excludeLine = (line: string): boolean => {
-    const exclusionCharacter = "#";
-    return line.includes(exclusionCharacter);
-  };
-
   return (
     <div className={classNames(styles.searchStrings)}>
-      {values.map((value, i) => {
-        const isExcluded = excludeLine(value);
-
-        // This function will only execute for non-excluded lines
-        const handleClick = () => {
-          navigator.clipboard.writeText(value);
-          toast.success("Copied to Clipboard");
-        };
-
-        return (
-          <div
-            key={i}
-            className={classNames(
-              borderListStyles.itemRound,
-              !isExcluded && interactiveStyles.hoverPrimary,
-              !isExcluded && interactiveStyles.activePrimary,
-              styles.searchString
-            )}
-            onClick={!isExcluded ? handleClick : undefined}
-          >
-            {/* Only render clipboard icon for non-excluded lines */}
-            {!isExcluded && (
-              <div onClick={handleClick}>
-                <FaRegClipboard className={classNames("inlineIcon")} />
-              </div>
-            )}
-            {value}
+      {values.map((value, i) => (
+        <div
+          key={i}
+          className={classNames(
+            borderListStyles.itemRound,
+            interactiveStyles.hoverPrimary,
+            interactiveStyles.activePrimary,
+            styles.searchString
+          )}
+          onClick={() => {
+            navigator.clipboard.writeText(value.text);
+            toast.success("Copied to Clipboard");
+          }}
+        >
+          <div>
+            <FaRegClipboard className={classNames("inlineIcon")} />
           </div>
-        );
-      })}
+          {value.alias || value.text}
+        </div>
+      ))}
     </div>
   );
 }

--- a/web/src/components/SearchStrings/index.tsx
+++ b/web/src/components/SearchStrings/index.tsx
@@ -9,6 +9,12 @@ interface SearchStringsProps {
 }
 
 export function SearchStrings({ values }: SearchStringsProps) {
+
+  const excludeLine = (line: string): boolean => {
+    const exclusionCharacter = "#";
+    return line.includes(exclusionCharacter);
+  };
+
   return (
     <div className={classNames(styles.searchStrings)}>
       {values.map((value, i) => (
@@ -25,9 +31,15 @@ export function SearchStrings({ values }: SearchStringsProps) {
             toast.success("Copied to Clipboard");
           }}
         >
-          <div>
+          {/* Only render clipboard icon and add copy functionality if line shouldn't be excluded */}
+          {!excludeLine(value) && (
+            <div onClick={() => {
+              navigator.clipboard.writeText(value);
+              toast.success("Copied to Clipboard");
+            }}>
             <FaRegClipboard className={classNames("inlineIcon")} />
           </div>
+          )}
           {value}
         </div>
       ))}

--- a/web/src/components/SearchStrings/index.tsx
+++ b/web/src/components/SearchStrings/index.tsx
@@ -17,32 +17,36 @@ export function SearchStrings({ values }: SearchStringsProps) {
 
   return (
     <div className={classNames(styles.searchStrings)}>
-      {values.map((value, i) => (
-        <div
-          key={i}
-          className={classNames(
-            borderListStyles.itemRound,
-            interactiveStyles.hoverPrimary,
-            interactiveStyles.activePrimary,
-            styles.searchString
-          )}
-          onClick={() => {
-            navigator.clipboard.writeText(value);
-            toast.success("Copied to Clipboard");
-          }}
-        >
-          {/* Only render clipboard icon and add copy functionality if line shouldn't be excluded */}
-          {!excludeLine(value) && (
-            <div onClick={() => {
-              navigator.clipboard.writeText(value);
-              toast.success("Copied to Clipboard");
-            }}>
-            <FaRegClipboard className={classNames("inlineIcon")} />
+      {values.map((value, i) => {
+        const isExcluded = excludeLine(value);
+
+        // This function will only execute for non-excluded lines
+        const handleClick = () => {
+          navigator.clipboard.writeText(value);
+          toast.success("Copied to Clipboard");
+        };
+
+        return (
+          <div
+            key={i}
+            className={classNames(
+              borderListStyles.itemRound,
+              !isExcluded && interactiveStyles.hoverPrimary,
+              !isExcluded && interactiveStyles.activePrimary,
+              styles.searchString
+            )}
+            onClick={!isExcluded ? handleClick : undefined}
+          >
+            {/* Only render clipboard icon for non-excluded lines */}
+            {!isExcluded && (
+              <div onClick={handleClick}>
+                <FaRegClipboard className={classNames("inlineIcon")} />
+              </div>
+            )}
+            {value}
           </div>
-          )}
-          {value}
-        </div>
-      ))}
+        );
+      })}
     </div>
   );
 }

--- a/web/src/components/SearchStringsEditor/index.tsx
+++ b/web/src/components/SearchStringsEditor/index.tsx
@@ -1,0 +1,37 @@
+import { searchStringsAtom } from "../../state/search-strings";
+import { formStyles } from "../../styles";
+import { CodeEditor } from "../CodeEditor";
+import styles from "./styles.module.css";
+import classNames from "classnames";
+import { Grammar } from "prismjs";
+import { useRecoilState } from "recoil";
+
+const SearchStringGrammar: Grammar = {
+  comment: /#.*/,
+};
+
+export function SearchStringsEditor() {
+  const [searchStrings, setSearchStrings] = useRecoilState(searchStringsAtom);
+
+  return (
+    <div className={classNames(formStyles.formRow)}>
+      <label>
+        Search Strings {"("}
+        <a href="https://poe.re/" target="_blank">
+          Path of Exile Regex
+        </a>
+        {/* TODO Should add some hints for alias format */}
+        {")"}
+      </label>
+      <CodeEditor
+        className={classNames(styles.input)}
+        grammar={SearchStringGrammar}
+        value={searchStrings?.join("\n") || ""}
+        onValueChange={(value) => {
+          if (value.length == 0) setSearchStrings(null);
+          else setSearchStrings(value.split(/\r\n|\r|\n/));
+        }}
+      />
+    </div>
+  );
+}

--- a/web/src/components/SearchStringsEditor/styles.module.css
+++ b/web/src/components/SearchStringsEditor/styles.module.css
@@ -1,0 +1,5 @@
+.input {
+  width: 100%;
+  height: 6rem;
+  resize: none;
+}

--- a/web/src/components/Sidebar/index.tsx
+++ b/web/src/components/Sidebar/index.tsx
@@ -1,6 +1,5 @@
-import { buildDataSelector } from "../../state/build-data";
 import { gemLinksSelector } from "../../state/gem-links";
-import { searchStringsAtom } from "../../state/search-strings";
+import { searchStringsSelector } from "../../state/search-strings";
 import { urlTreesSelector } from "../../state/tree/url-tree";
 import { interactiveStyles } from "../../styles";
 import { GemLinkViewer } from "../GemLinkViewer";
@@ -16,7 +15,7 @@ import { TbHierarchy } from "react-icons/tb";
 import { useRecoilValue } from "recoil";
 
 export function Sidebar() {
-  const searchStrings = useRecoilValue(searchStringsAtom);
+  const searchStrings = useRecoilValue(searchStringsSelector);
   const { urlTrees } = useRecoilValue(urlTreesSelector);
   const gemLinks = useRecoilValue(gemLinksSelector);
   const [expand, setExpand] = useState(true);

--- a/web/src/containers/Build/index.tsx
+++ b/web/src/containers/Build/index.tsx
@@ -1,16 +1,15 @@
 import { BuildInfoForm, GemOrderList } from "../../components/BuildEditForm";
 import { BuildImportForm } from "../../components/BuildImportForm";
+import { SearchStringsEditor } from "../../components/SearchStringsEditor";
 import { buildDataSelector } from "../../state/build-data";
 import { requiredGemsSelector } from "../../state/gem";
-import { searchStringsAtom } from "../../state/search-strings";
-import { buildTreesSelector } from "../../state/tree/build-tree";
 import { gemLinksSelector } from "../../state/gem-links";
+import { buildTreesSelector } from "../../state/tree/build-tree";
+import { formStyles } from "../../styles";
 import { withBlank } from "../../utility/withBlank";
 import { withScrollRestoration } from "../../utility/withScrollRestoration";
-import styles from "./styles.module.css";
 import classNames from "classnames";
 import { useRecoilState, useResetRecoilState } from "recoil";
-import { formStyles } from "../../styles";
 
 function BuildContainer() {
   const [buildData, setBuildData] = useRecoilState(buildDataSelector);
@@ -22,9 +21,9 @@ function BuildContainer() {
   const [buildTrees, setBuildTreesSelector] =
     useRecoilState(buildTreesSelector);
   const resetBuildTreesSelector = useResetRecoilState(buildTreesSelector);
-  
+
   const [gemLinks, setGemLinks] = useRecoilState(gemLinksSelector);
-  const resetGemLinks = useResetRecoilState(gemLinksSelector)
+  const resetGemLinks = useResetRecoilState(gemLinksSelector);
 
   return (
     <div>
@@ -36,7 +35,7 @@ function BuildContainer() {
       />
       <hr />
       <div className={classNames(formStyles.form)}>
-        <EditSearchStrings />
+        <SearchStringsEditor />
         <BuildImportForm
           onSubmit={(pobData) => {
             setBuildData(pobData.buildData);
@@ -64,35 +63,6 @@ function BuildContainer() {
           <hr />
         </>
       )}
-    </div>
-  );
-}
-
-function EditSearchStrings() {
-  const [searchStrings, setSearchStrings] = useRecoilState(searchStringsAtom);
-
-  return (
-    <div className={classNames(formStyles.formRow)}>
-      <label>
-        Search Strings {"("}
-        <a href="https://poe.re/" target="_blank">
-          Path of Exile Regex
-        </a>
-        {")"}
-      </label>
-      <textarea
-        spellCheck={false}
-        className={classNames(formStyles.formInput, styles.searchStringsInput)}
-        value={searchStrings?.join("\n")}
-        onChange={(e) => {
-          if (e.target.value.length == 0) setSearchStrings(null);
-          else
-            setSearchStrings(
-              e.target.value.split(/\r\n|\r|\n/).map((x) => x.trim())
-            );
-        }}
-        aria-label="Search Strings"
-      />
     </div>
   );
 }

--- a/web/src/containers/Build/styles.module.css
+++ b/web/src/containers/Build/styles.module.css
@@ -1,5 +1,0 @@
-.searchStringsInput {
-  width: 100%;
-  height: 5rem;
-  resize: none;
-}

--- a/web/src/state/search-strings.ts
+++ b/web/src/state/search-strings.ts
@@ -1,8 +1,13 @@
 import { persistentStorageEffect } from ".";
 import { NO_MIGRATORS, getPersistent } from "../utility";
-import { atom } from "recoil";
+import { atom, selector } from "recoil";
 
 const SEARCH_STRINGS_VERSION = 0;
+
+export interface SearchString {
+  text: string;
+  alias?: string;
+}
 
 export const searchStringsAtom = atom<string[] | null>({
   key: "searchStringsAtom",
@@ -12,4 +17,30 @@ export const searchStringsAtom = atom<string[] | null>({
     NO_MIGRATORS
   ),
   effects: [persistentStorageEffect("search-strings", SEARCH_STRINGS_VERSION)],
+});
+
+export const searchStringsSelector = selector({
+  key: "searchStringsSelector",
+  get: async ({ get }) => {
+    const rawSearchStrings = get(searchStringsAtom);
+    if (!rawSearchStrings) return null;
+
+    let alias: string | undefined = undefined;
+    let searchStrings: SearchString[] = [];
+    for (let i = 0; i < rawSearchStrings.length; i++) {
+      const line = rawSearchStrings[i];
+      if (line.startsWith("#")) {
+        alias = line.substring(1).trim();
+      } else if (/\S/.test(line)) {
+        searchStrings.push({
+          text: line.trim(),
+          alias: alias,
+        });
+
+        alias = undefined;
+      }
+    }
+
+    return searchStrings;
+  },
 });


### PR DESCRIPTION
I _love_ the string copying functionality, but plain regex can be a bit hard to parse at a quick glance. I usually add additional strings that include some indicator of what the regex represents, or strings to separate the regex by Act. However, those can be copied as well.

I updated the feature to exclude any strings containing `#`. Clicking the excluded line will not copy its text or generate a toast. `#` is used in regex, but to my knowledge, it wouldn't apply to any usage from https://poe.re/ although another character (such as `@`) might be a better candidate.

![CleanShot 2023-08-13 at 17 13 42](https://github.com/HeartofPhos/exile-leveling/assets/28898416/57a97165-6bd2-4fb2-b780-f94277a010db)

Note: I am not a software dev, so there may be a better method for implementing this - please feel free to reject this PR. Happy to share this feedback as an issue if that's preferred instead, just lmk.
